### PR TITLE
Add simple WinForms server GUI

### DIFF
--- a/VoidTogetherServerCS/MainForm.cs
+++ b/VoidTogetherServerCS/MainForm.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+public class MainForm : Form
+{
+    ListBox lstPlayers = new();
+    TextBox txtLog = new() { Multiline = true, ReadOnly = true, ScrollBars = ScrollBars.Vertical };
+    TextBox txtCommand = new();
+    Button btnSend = new() { Text = "Send" };
+    Button btnStart = new() { Text = "Start Server" };
+    PropertyGrid grid = new();
+
+    bool running = false;
+
+    public MainForm()
+    {
+        Text = "VoidTogether Server";
+        Width = 800;
+        Height = 600;
+
+        grid.SelectedObject = Program.Config.properties;
+        grid.Dock = DockStyle.Left;
+        grid.Width = 250;
+
+        lstPlayers.Dock = DockStyle.Right;
+        lstPlayers.Width = 200;
+
+        txtLog.Dock = DockStyle.Fill;
+
+        Panel bottom = new() { Dock = DockStyle.Bottom, Height = 30 };
+        txtCommand.Dock = DockStyle.Fill;
+        btnSend.Dock = DockStyle.Right;
+        btnStart.Dock = DockStyle.Left;
+        bottom.Controls.Add(btnStart);
+        bottom.Controls.Add(txtCommand);
+        bottom.Controls.Add(btnSend);
+
+        Controls.Add(txtLog);
+        Controls.Add(grid);
+        Controls.Add(lstPlayers);
+        Controls.Add(bottom);
+
+        btnStart.Click += (s, e) =>
+        {
+            if (!running)
+            {
+                Program.StartServer(Log, RefreshPlayers);
+                running = true;
+                btnStart.Text = "Stop Server";
+            }
+            else
+            {
+                Program.StopServer();
+                running = false;
+                btnStart.Text = "Start Server";
+                RefreshPlayers();
+            }
+        };
+
+        btnSend.Click += (s, e) =>
+        {
+            Program.ExecuteCommand(txtCommand.Text, Log);
+            txtCommand.Clear();
+        };
+    }
+
+    void Log(string text)
+    {
+        if (txtLog.InvokeRequired)
+        {
+            txtLog.Invoke(new Action<string>(Log), text);
+            return;
+        }
+        txtLog.AppendText(text + Environment.NewLine);
+    }
+
+    void RefreshPlayers()
+    {
+        if (lstPlayers.InvokeRequired)
+        {
+            lstPlayers.Invoke(new Action(RefreshPlayers));
+            return;
+        }
+        lstPlayers.Items.Clear();
+        foreach (var p in Program.Players)
+            lstPlayers.Items.Add(p.Username);
+    }
+}

--- a/VoidTogetherServerCS/VoidTogetherServerCS.csproj
+++ b/VoidTogetherServerCS/VoidTogetherServerCS.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- convert server to WinForms app
- add `MainForm` for editing config, viewing players and running commands
- expose helpers in `Program` for starting/stopping server and executing commands
- adjust project file for Windows Forms

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5864440832fa5640fcb7bc7571f