### PR TITLE
Fix logging delegate type

### DIFF
--- a/VoidTogetherServerCS/Program.cs
+++ b/VoidTogetherServerCS/Program.cs
@@ -23,7 +23,7 @@ class Program
     internal static List<Player> Players = new();
     internal static int NextUserId = 0;
     static WebSocketServer? _server;
-    static Action? _log;
+    static Action<string>? _log;
     static Action? _updatePlayers;
 
     [STAThread]


### PR DESCRIPTION
## Summary
- fix assignment to `_log` delegate

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ea88f4c90832f9985ddf08d146083